### PR TITLE
queue Command

### DIFF
--- a/.env_example
+++ b/.env_example
@@ -1,3 +1,4 @@
 BOT_TOKEN=your_token_goes_here
 BOT_PREFIX=.
+BOT_COLOR=ff0000
 PRINT_STACK_TRACE=true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
     - alternate: `.p`
 - `.skip {n}` - skips `n` videos. Without `n`, skips only once. `.skip all` will skip every song and leave the VC.
     - alternate: `.s`
+- `.queue` - shows a list of titles queued for playback
+    - alternate: `.q`
 
 ## Getting started
 Recently, some of the major Discord bots designed to play YouTube videos (Rythm and Groovy to name a few) have been taken down by Google for copyright infringment. This means that I can't just give you a bot to add to your server, but I can give you the code to run on your own bot, which you can add to your server. Don't worry, this is a pretty straightforward process.

--- a/youtubebot.py
+++ b/youtubebot.py
@@ -24,8 +24,7 @@ except ValueError:
     COLOR = 0xff0000
 
 bot = commands.Bot(command_prefix=PREFIX, intents=discord.Intents(voice_states=True, guilds=True, guild_messages=True, message_content=True))
-queues = {} # {server_id: [vid_file, ...]}
-            # {server_id: [(vid_file, info), ...]}
+queues = {} # {server_id: [(vid_file, info), ...]}
 
 def main():
     if TOKEN is None:

--- a/youtubebot.py
+++ b/youtubebot.py
@@ -19,6 +19,7 @@ PRINT_STACK_TRACE = os.getenv('PRINT_STACK_TRACE', '1').lower() in ('true', 't',
 
 bot = commands.Bot(command_prefix=PREFIX, intents=discord.Intents(voice_states=True, guilds=True, guild_messages=True, message_content=True))
 queues = {} # {server_id: [vid_file, ...]}
+            # {server_id: [(vid_file, info), ...]}
 
 def main():
     if TOKEN is None:
@@ -27,6 +28,20 @@ def main():
     try: bot.run(TOKEN)
     except discord.PrivilegedIntentsRequired as error:
         return error
+
+@bot.command(name='queue', aliases=['q'])
+async def queue(ctx: commands.Context, *args):
+    try: queue = queues[ctx.guild.id]
+    except KeyError: queue = None
+    if queue == None:
+        await ctx.send('the bot isn\'t playing anything')
+    else:
+        lst = ''
+        for song in queue:
+            lst
+        await ctx.send('there are %d songs in the queue:\n%s')
+    if not await sense_checks(ctx):
+        return
 
 @bot.command(name='skip', aliases=['s'])
 async def skip(ctx: commands.Context, *args):
@@ -89,7 +104,7 @@ async def play(ctx: commands.Context, *args):
         ydl.download([query])
         
         path = f'./dl/{server_id}/{info["id"]}.{info["ext"]}'
-        try: queues[server_id].append(path)
+        try: queues[server_id].append((path, info))
         except KeyError: # first in queue
             queues[server_id] = [path]
             try: connection = await voice_state.channel.connect()


### PR DESCRIPTION
Hey, i added a `.queue` aka `.q` command to be able to view the current playback queue.

The bot responds with an embed containing a list of titles.

README.md has been updated accordingly

More Info:
To accomplish this i had to store the titles together with the path to the file.
I chose to store the info object of the video, this allows for access to all info of a video and will be useful for further expansion.

Embeds in Discord have a color band at the side, this color can be customized. To allow for color customization in the bot i added a BOT_COLOR line to the .env file.
This excepts 2digit per color (R,G & B) hex values.
*Example: ffaa11 where red = 255(ff), green =  170(aa) and blue = 17(11)*
I set the default color for this to red, as all embeds of youtube links have a red band as well.