### PR TITLE
Adding systemd example

### DIFF
--- a/systemd/README.md
+++ b/systemd/README.md
@@ -1,0 +1,29 @@
+## Integration with systemd
+
+If you want to use the bot on your systemd machine you have to create a systemd unit for it. You can use the `youtubebot.service` example in this file.
+
+Decide if you want to use it inside your user session or system session. 
+
+User folder: `~/.config/systemd/user/youtubebot.service`  
+System folder: `/etc/systemd/system/youtubebot.service`
+
+## Using Python virtual env
+
+If you are using a virtual environment for the bot change the ExecStart= so it points to the path of the virtualenv python binary. 
+
+## Usage
+If you use the system installation, don't use the `--user` parameter. 
+
+### Starting
+`systemctl --user start youtubebot.service`
+
+### Stoping
+`systemctl --user stop youtubebot.service` 
+
+### Autostart
+`systemctl --user enable youtubebot.service`
+
+### View logs
+`journactl --user youtubebot.service`
+
+

--- a/systemd/youtubebot.service
+++ b/systemd/youtubebot.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Discord youtube bot
+
+[Service]
+# You can use %h/<path> for substitution to the home directory
+ExecStart=/usr/bin/env python %h/YoutubeBot/youtubebot.py
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
I've created a systemd example config file, which could be used for running the service fully integrated in modern Linux distribution. 

It's just a file to be copy & pasted. It allows users to autostart the bot and simplifies managing the process. 